### PR TITLE
Remove min-width of NavItem

### DIFF
--- a/src/components/MobileNav.vue
+++ b/src/components/MobileNav.vue
@@ -168,7 +168,6 @@ watchEffect(() => {
       justify-content: center;
       align-items: center;
       box-sizing: border-box;
-      min-width: 85px;
       height: v-bind(containerHeightCss);
       padding: 0px 12px;
       gap: 4px;


### PR DESCRIPTION
在使用了放大字体的iPhone上面，viewport只有320x655。此时NavList会太宽以至于超出屏幕：
<img width="286" alt="图片" src="https://github.com/Wetoria/sy-plugin-enhance/assets/12483662/c75831cf-fb34-4d4a-be5d-ad1878728e67">
将 `min-width` 删除后则没有这个问题。
<img width="279" alt="图片" src="https://github.com/Wetoria/sy-plugin-enhance/assets/12483662/49dfae3b-77e8-44c5-aa12-22c83325bb98">
